### PR TITLE
Add spack sundials to BOUT

### DIFF
--- a/packages/hermes-3/package.py
+++ b/packages/hermes-3/package.py
@@ -38,6 +38,9 @@ class Hermes3(CMakePackage):
         multi=False,
     )
     variant("petsc", default=False, description="Builds with PETSc support.")
+    # variant where SUNDIALS is downloaded by BOUT
+    variant("bout-sundials", default=False, description="Builds with SUNDIALS support, SUNDIALS downloaded by BOUT++.")
+    # variant where SUNDIALS comes from spack
     variant("sundials", default=True, description="Builds with SUNDIALS support.")
     variant(
         "xhermes", default=True, description="Builds xhermes (required for some tests)."
@@ -59,17 +62,18 @@ class Hermes3(CMakePackage):
         "petsc+hypre+mpi~debug~fortran", when="+petsc", type=("build", "link", "run")
     )
     depends_on("py-xhermes", when="+xhermes", type=("build", "link", "run"))
-
-    # Could add Sundials as a spack dependency here?
-    # Download it via the BOUT cmake flag for now (see binary_def_variants, below)
-    # depends_on("sundials", when="+sundials", type=("build", "link", "run"))
+    # SUNDIALS spack dependency
+    depends_on("sundials", when="+sundials", type=("build", "link", "run"))
+    # or instead, download SUNDIALS via the
+    # BOUT cmake flag (see binary_def_variants, below)
 
     def cmake_args(self):
         # ON/OFF definitions controlled by variants
         binary_def_variants = {
-            "BOUT_DOWNLOAD_SUNDIALS": "sundials",
+            "BOUT_DOWNLOAD_SUNDIALS": "bout-sundials",
             "HERMES_SLOPE_LIMITER": "limiter",
             "BOUT_USE_PETSC": "petsc",
+            "BOUT_USE_SUNDIALS": "sundials",
         }
         variants_args = [
             self.define_from_variant(def_str, var_str)

--- a/packages/hermes-3/package.py
+++ b/packages/hermes-3/package.py
@@ -38,9 +38,6 @@ class Hermes3(CMakePackage):
         multi=False,
     )
     variant("petsc", default=False, description="Builds with PETSc support.")
-    # variant where SUNDIALS is downloaded by BOUT
-    variant("bout-sundials", default=False, description="Builds with SUNDIALS support, SUNDIALS downloaded by BOUT++.")
-    # variant where SUNDIALS comes from spack
     variant("sundials", default=True, description="Builds with SUNDIALS support.")
     variant(
         "xhermes", default=True, description="Builds xhermes (required for some tests)."
@@ -62,15 +59,11 @@ class Hermes3(CMakePackage):
         "petsc+hypre+mpi~debug~fortran", when="+petsc", type=("build", "link", "run")
     )
     depends_on("py-xhermes", when="+xhermes", type=("build", "link", "run"))
-    # SUNDIALS spack dependency
     depends_on("sundials", when="+sundials", type=("build", "link", "run"))
-    # or instead, download SUNDIALS via the
-    # BOUT cmake flag (see binary_def_variants, below)
 
     def cmake_args(self):
         # ON/OFF definitions controlled by variants
         binary_def_variants = {
-            "BOUT_DOWNLOAD_SUNDIALS": "bout-sundials",
             "HERMES_SLOPE_LIMITER": "limiter",
             "BOUT_USE_PETSC": "petsc",
             "BOUT_USE_SUNDIALS": "sundials",


### PR DESCRIPTION
Refactor so that the spack version of SUNDIALS is installed by default (with variant `+sundials`), whereas the variant `+bout-sundials` forces BOUT to download SUNDIALS. This commit changes the default behaviour, with the view that it is best for all packages to be handled by spack directly. A manually installed version of Hermes-3 compiles (with warnings) and passes the `ctest` tests with this commit of BOUT-spack.

On the compilation stage of a manual install, new warnings appear in the compilation of Hermes-3

```
[ 94%] Generating libboutpp.cpp
warning: resolve_enum.pxd:49:21: 'deflt' redeclared
warning: resolve_enum.pxd:189:24: 'Standard' redeclared
warning: resolve_enum.pxd:223:15: 'Standard' redeclared
performance hint: libboutpp.pyx:2149:5: Exception check on 'callback' will always require the GIL to be acquired.
Possible solutions:
        1. Declare 'callback' as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
        2. Use an 'int' return type on 'callback' to allow an error code to be returned.
[ 94%] Building CXX object external/BOUT-dev/tools/pylib/_boutpp_build/CMakeFiles/boutpp.cpython-311-x86_64-linux-gnu.dir/libboutpp.cpp.o
In file included from /home/mrhardman/software/spack_v231/opt/spack/linux-ubuntu22.04-skylake/gcc-11.4.0/py-numpy-1.25.2-l35tbrmpy5j27f5poob3n2hjp3d5ohtl/lib/python3.11/site-packages/numpy/core/include/numpy/ndarraytypes.h:1929,
                 from /home/mrhardman/software/spack_v231/opt/spack/linux-ubuntu22.04-skylake/gcc-11.4.0/py-numpy-1.25.2-l35tbrmpy5j27f5poob3n2hjp3d5ohtl/lib/python3.11/site-packages/numpy/core/include/numpy/ndarrayobject.h:12,
                 from /home/mrhardman/software/spack_v231/opt/spack/linux-ubuntu22.04-skylake/gcc-11.4.0/py-numpy-1.25.2-l35tbrmpy5j27f5poob3n2hjp3d5ohtl/lib/python3.11/site-packages/numpy/core/include/numpy/arrayobject.h:5,
                 from /home/mrhardman/hermes-3-work/hermes-3-spack/spack-oparry-devbuilds/build-sundials/external/BOUT-dev/tools/pylib/_boutpp_build/libboutpp.cpp:1268:
/home/mrhardman/software/spack_v231/opt/spack/linux-ubuntu22.04-skylake/gcc-11.4.0/py-numpy-1.25.2-l35tbrmpy5j27f5poob3n2hjp3d5ohtl/lib/python3.11/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: #warning "Using deprecated NumPy API, disable it with " "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
   17 | #warning "Using deprecated NumPy API, disable it with " \
      |  ^~~~~~~
```
but the tests do pass with a manual install from the hermes-3 root folder in the spack install enviroment (here mocked up by `inhermes3`)
```
$  inhermes3 cmake -B build-sundials -DBOUT_USE_PETSC=ON -DBOUT_USE_SUNDIALS=ON
$ inhermes3 cmake --build build-sundials
$ cd build-sundials/
build-sundials$ inhermes3 ctest
spack build-env hermes-3%gcc ctest
Test project /home/mrhardman/hermes-3-work/hermes-3-spack/spack-oparry-devbuilds/build-sundials
      Start  1: 1D-fluid
 1/11 Test  #1: 1D-fluid .........................   Passed    3.28 sec
      Start  2: 1D-recycling
 2/11 Test  #2: 1D-recycling .....................   Passed   36.70 sec
      Start  3: diffusion
 3/11 Test  #3: diffusion ........................   Passed    0.28 sec
      Start  4: evolve_density
 4/11 Test  #4: evolve_density ...................   Passed    0.25 sec
      Start  5: neutral_mixed
 5/11 Test  #5: neutral_mixed ....................   Passed    3.72 sec
      Start  6: vorticity
 6/11 Test  #6: vorticity ........................   Passed    0.53 sec
      Start  7: sod-shock
 7/11 Test  #7: sod-shock ........................   Passed    2.37 sec
      Start  8: sod-shock-energy
 8/11 Test  #8: sod-shock-energy .................   Passed    2.28 sec
      Start  9: drift-wave
 9/11 Test  #9: drift-wave .......................   Passed    8.71 sec
      Start 10: alfven-wave
10/11 Test #10: alfven-wave ......................   Passed    5.45 sec
      Start 11: hermes_unit_tests
11/11 Test #11: hermes_unit_tests ................   Passed    0.04 sec

100% tests passed, 0 tests failed out of 11

Total Test time (real) =  63.62 sec
```